### PR TITLE
Purge trailing whitespace

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -58,15 +58,15 @@ and new relations:
     New tables:
       + sessions
       + jobs
-    
+
     New columns:
       + users
          + age
-    
+
     Changed columns:
       + users
          + username: varchar(255)
-    
+
     New relations:
       + users -> sessions
 

--- a/lib/MySQL/Workbench/Merge.pm
+++ b/lib/MySQL/Workbench/Merge.pm
@@ -322,15 +322,15 @@ and new relations:
     New tables:
       + sessions
       + jobs
-    
+
     New columns:
       + users
          + age
-    
+
     Changed columns:
       + users
          + username: varchar(255)
-    
+
     New relations:
       + users -> sessions
 

--- a/t/Role.pm
+++ b/t/Role.pm
@@ -1,6 +1,6 @@
 package
    MyApp::DB::DBIC_Schema::Result::Role;
-    
+
 use strict;
 use warnings;
 use base qw(DBIx::Class);


### PR DESCRIPTION
Some projects consider this a must, and will disallow commits to be
submitted which contain trailing whitespace (the Linux kernel is an
example project where trailing whitespace isn't permitted).  Other
projects see whitespace cleanup as simply nit-picking.  Either way, I
thought it could be helpful :-)  Please feel free to close this PR unmerged if you don't want this change.