### PR TITLE
Indent print statements

### DIFF
--- a/lib/MySQL/Workbench/Merge.pm
+++ b/lib/MySQL/Workbench/Merge.pm
@@ -69,7 +69,7 @@ sub merge {
     my ($diagram)     = $dom->documentElement->findnodes( $diagram_xpath );
 
     for my $table ( sort keys %{ $diff{new_tables} || {} } ) {
-print STDERR sprintf "Merge %s into schema\n", $table;
+        print STDERR sprintf "Merge %s into schema\n", $table;
         my $info   = $diff{new_tables}->{$table};
         my $node   = $info->{node};
         my $figure = $info->{figure};
@@ -85,7 +85,7 @@ print STDERR sprintf "Merge %s into schema\n", $table;
             my $xpath    = sprintf './/value[@id="%s"]/value[@content-struct-name="db.mysql.Column"]',
                 $table_id;
 
-print STDERR "TABLE ID: $table_id\n";
+            print STDERR "TABLE ID: $table_id\n";
 
             my ($schema) = $dom->documentElement->findnodes( $xpath );
             $schema->addChild( $node );


### PR DESCRIPTION
Hi Renee,

I'm nitpicking again ;-)

Two print statements were outdented to the left margin which put them
out of context of the surrounding code.  This change indents them to be
indented the same as the surrounding code.

At first I thought this might have been code style to make the `print` statements stand out, however not all `print STDERR` statements were "outdented" to the left hand margin, hence I thought it's probably better to indent the code to be consistent with the surrounding code and stop "wtf?" moments when reading the code.