### PR TITLE
Fix merge test suite failures

### DIFF
--- a/lib/MySQL/Workbench/Merge.pm
+++ b/lib/MySQL/Workbench/Merge.pm
@@ -75,7 +75,7 @@ print STDERR sprintf "Merge %s into schema\n", $table;
         my $figure = $info->{figure};
 
         $schema->addChild( $node );
-        $diagram->addChild( $figure );
+        $diagram->addChild( $figure ) if $figure;
     }
 
     for my $table ( sort keys %{ $diff{new_columns} || {} } ) {

--- a/t/02_merge.t
+++ b/t/02_merge.t
@@ -56,7 +56,6 @@ my $base = dirname __FILE__;
 
     is $error, '';
     diag $target;
-    die 'hallo';
 }
 
 done_testing();


### PR DESCRIPTION
This PR fixes the test failures I found when running the `02_merge.t` test suite.  I'm not 100% sure about my fix for the first test because I'm not sure if that's what was intended.  It looks like it was intended that one of the files to merge should not be available and that a particular error message was expected.  The missing file causes part of the expected structure to be missing and hence the `figure` compontent is null when being added to the diagram.  This causes `XML::LibXML` (which is used internally by an upstream dependency) to barf and hence the test fails.  By checking if the `figure` component exists before trying to add it causes this test to pass.

The second test was failing due to the line:

```
die 'hallo';
```

which looks like it's intended as a debugging statement of some kind and doesn't actually add to the sense of the test.  Therefore I removed this line and now the test suite is passing.

I hope these fixes are correct!  Please let me know if anything should be changed.  If you want anything updated, just let me know and I'll be happy to fix and resubmit :-)